### PR TITLE
feat: add ValidationLevel enum + comprehensive profile safety validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,12 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+.continuity/
+
+# Continuity
+SESSION_HANDOFF.md
+
+AGENTS.md
+CLAUDE.md
+GEMINI.md

--- a/meticulous-mcp/src/meticulous_mcp/profile_validator.py
+++ b/meticulous-mcp/src/meticulous_mcp/profile_validator.py
@@ -18,11 +18,29 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import json
 import os
+import re
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 import jsonschema
 from jsonschema import ValidationError
+
+
+class ValidationLevel(Enum):
+    """Controls which checks are run during profile validation.
+
+    Levels:
+    - MACHINE: Schema conformance + hardware limits only. Use when you trust the
+      profile author and only want to catch machine-breaking errors.
+    - SAFETY (default): Everything in MACHINE plus shot-safety best-practice
+      checks (backup triggers, required limits, redundant limits, etc.).
+    - STRICT: Everything in SAFETY plus app-UI convention checks (variable
+      naming conventions, emoji rules, etc.).
+    """
+    MACHINE = "machine"
+    SAFETY = "safety"
+    STRICT = "strict"
 
 
 class ProfileValidationError(Exception):
@@ -53,13 +71,16 @@ class ProfileValidationError(Exception):
 class ProfileValidator:
     """Validates espresso profiles against JSON schema."""
 
-    def __init__(self, schema_path: Optional[str] = None):
+    def __init__(self, schema_path: Optional[str] = None, level: ValidationLevel = ValidationLevel.SAFETY):
         """Initialize the validator.
-        
+
         Args:
             schema_path: Path to schema.json file. If not provided, attempts to find
                         it relative to this file or in espresso-profile-schema repo.
+            level: Default validation level to use when none is passed to validate().
+                   Defaults to ValidationLevel.SAFETY.
         """
+        self._default_level = level
         possible_paths = []
         if schema_path is None:
             # Try to find schema relative to this file
@@ -86,42 +107,96 @@ class ProfileValidator:
         # Create validator instance
         self._validator = jsonschema.Draft7Validator(self._schema)
 
-    def validate(self, profile: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    def validate(self, profile: Dict[str, Any], level: Optional[ValidationLevel] = None) -> Tuple[bool, List[str]]:
         """Validate a profile against the schema.
-        
+
         Args:
             profile: Profile dictionary to validate
-            
+            level: Validation level to use. Defaults to the level set at construction
+                   time (ValidationLevel.SAFETY if not specified).
+
         Returns:
             Tuple of (is_valid, list_of_errors)
         """
+        if level is None:
+            level = self._default_level
+
         errors = []
         try:
             self._validator.validate(profile)
         except ValidationError as e:
             errors.append(self._format_error(e))
-            
+
             # Collect all validation errors
             for error in self._validator.iter_errors(profile):
                 if error != e:  # Don't duplicate the first error
                     errors.append(self._format_error(error))
-        
-        # Add custom validation for pressure limits (15 bar max)
-        pressure_errors = self._validate_pressure_limits(profile)
-        errors.extend(pressure_errors)
-        
+
+        # --- MACHINE level checks (always run) ---------------------------------
+        # Hardware limits and schema-level constraints that, if violated, will
+        # cause the machine to behave dangerously or reject the profile entirely.
+
+        # Pressure limits (15 bar max)
+        errors.extend(self._validate_pressure_limits(profile))
+
+        # Interpolation values (only 'linear' and 'curve' supported)
+        errors.extend(self._validate_interpolation(profile))
+
+        # dynamics.over values
+        errors.extend(self._validate_dynamics_over(profile))
+
+        # Stage types
+        errors.extend(self._validate_stage_types(profile))
+
+        # Exit trigger types and comparison operators
+        errors.extend(self._validate_exit_triggers(profile))
+
+        # Limit types (validity only — redundancy is a SAFETY check)
+        errors.extend(self._validate_limit_types(profile))
+
+        # Absolute weight trigger monotonicity
+        errors.extend(self._validate_absolute_weight_triggers(profile))
+
+        # --- SAFETY level checks (run at SAFETY and STRICT) --------------------
+        # Best-practice shot-safety patterns. Violations won't necessarily crash
+        # the machine but can cause dangerous shots or indefinite stalls.
+        if level in (ValidationLevel.SAFETY, ValidationLevel.STRICT):
+            # Redundant limits (same type as stage control)
+            errors.extend(self._validate_redundant_limits(profile))
+
+            # Exit trigger type must not match stage control type
+            errors.extend(self._validate_exit_trigger_matches_stage_type(profile))
+
+            # Every stage needs a backup/failsafe exit trigger
+            errors.extend(self._validate_backup_exit_triggers(profile))
+
+            # Flow stages need pressure limits; pressure stages need flow limits
+            errors.extend(self._validate_required_limits(profile))
+
+            # Adjustable variables that are defined but never used
+            errors.extend(self._validate_unused_adjustable_variables(profile))
+
+        # --- STRICT level checks (run only at STRICT) --------------------------
+        # App-UI convention checks. Violations affect the user experience in the
+        # Meticulous app but do not affect shot safety or machine operation.
+        if level == ValidationLevel.STRICT:
+            # Variable naming conventions (emoji rules)
+            errors.extend(self._validate_variable_naming(profile))
+
         return len(errors) == 0, errors
 
-    def validate_and_raise(self, profile: Dict[str, Any]) -> None:
+    def validate_and_raise(self, profile: Dict[str, Any], level: Optional[ValidationLevel] = None) -> None:
         """Validate a profile and raise ProfileValidationError if invalid.
-        
+
         Args:
             profile: Profile dictionary to validate
-            
+            level: Validation level to use. Defaults to the level set at construction
+                   time (ValidationLevel.SAFETY if not specified).
+
         Raises:
             ProfileValidationError: If validation fails (includes all errors in message)
         """
-        is_valid, errors = self.validate(profile)
+        is_valid, errors = self.validate(profile, level=level)
         if not is_valid:
             message = f"Profile validation failed with {len(errors)} error(s)"
             # The ProfileValidationError will automatically include all errors in its message
@@ -171,6 +246,568 @@ class ProfileValidator:
                         elif pressure_val < 0:
                             errors.append(f"Stage '{stage_name}' exit trigger {trigger_idx+1} has negative pressure {pressure_val} bar. Pressure must be non-negative.")
         
+        return errors
+
+    def _validate_interpolation(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate interpolation values in profile dynamics.
+        
+        The Meticulous machine only supports 'linear' and 'curve' interpolation.
+        The value 'none' is not supported and will cause the machine to stall.
+        
+        Args:
+            profile: Profile dictionary to validate
+            
+        Returns:
+            List of interpolation-related validation errors
+        """
+        errors = []
+        valid_interpolations = {"linear", "curve"}
+        
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+        
+        for i, stage in enumerate(profile["stages"]):
+            if not isinstance(stage, dict):
+                continue
+            
+            stage_name = stage.get("name", f"Stage {i+1}")
+            dynamics = stage.get("dynamics", {})
+            
+            if isinstance(dynamics, dict):
+                interpolation = dynamics.get("interpolation")
+                if interpolation is not None and interpolation not in valid_interpolations:
+                    errors.append(
+                        f"Stage '{stage_name}' has invalid interpolation value '{interpolation}'. "
+                        f"Only 'linear' and 'curve' are supported. "
+                        f"The value 'none' is not supported by the Meticulous machine and will cause it to stall."
+                    )
+                
+                # Check that 'curve' interpolation has at least 2 points
+                points = dynamics.get("points", [])
+                if interpolation == "curve" and len(points) < 2:
+                    errors.append(
+                        f"Stage '{stage_name}' uses 'curve' interpolation but has only {len(points)} point(s). "
+                        f"Curve interpolation requires at least 2 points. Use 'linear' for single-point dynamics."
+                    )
+        
+        return errors
+
+    def _validate_dynamics_over(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate dynamics.over values in profile.
+        
+        The 'over' field must be one of: 'time', 'weight', 'piston_position'.
+        
+        Args:
+            profile: Profile dictionary to validate
+            
+        Returns:
+            List of dynamics.over validation errors
+        """
+        errors = []
+        valid_over_values = {"time", "weight", "piston_position"}
+        
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+        
+        for i, stage in enumerate(profile["stages"]):
+            if not isinstance(stage, dict):
+                continue
+            
+            stage_name = stage.get("name", f"Stage {i+1}")
+            dynamics = stage.get("dynamics", {})
+            
+            if isinstance(dynamics, dict):
+                over = dynamics.get("over")
+                if over is not None and over not in valid_over_values:
+                    errors.append(
+                        f"Stage '{stage_name}' has invalid dynamics.over value '{over}'. "
+                        f"Must be one of: 'time', 'weight', 'piston_position'."
+                    )
+        
+        return errors
+
+    def _validate_stage_types(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate stage type values in profile.
+        
+        Stage type must be one of: 'power', 'flow', 'pressure'.
+        
+        Args:
+            profile: Profile dictionary to validate
+            
+        Returns:
+            List of stage type validation errors
+        """
+        errors = []
+        valid_stage_types = {"power", "flow", "pressure"}
+        
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+        
+        for i, stage in enumerate(profile["stages"]):
+            if not isinstance(stage, dict):
+                continue
+            
+            stage_name = stage.get("name", f"Stage {i+1}")
+            stage_type = stage.get("type")
+            
+            if stage_type is not None and stage_type not in valid_stage_types:
+                errors.append(
+                    f"Stage '{stage_name}' has invalid type '{stage_type}'. "
+                    f"Must be one of: 'power', 'flow', 'pressure'."
+                )
+        
+        return errors
+
+    def _validate_exit_triggers(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate exit trigger values in profile.
+        
+        Exit trigger type must be one of: 'weight', 'pressure', 'flow', 'time', 
+        'piston_position', 'power', 'user_interaction'.
+        Comparison must be one of: '>=', '<='.
+        
+        Args:
+            profile: Profile dictionary to validate
+            
+        Returns:
+            List of exit trigger validation errors
+        """
+        errors = []
+        valid_trigger_types = {"weight", "pressure", "flow", "time", "piston_position", "power", "user_interaction"}
+        valid_comparisons = {">=", "<="}
+        
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+        
+        for i, stage in enumerate(profile["stages"]):
+            if not isinstance(stage, dict):
+                continue
+            
+            stage_name = stage.get("name", f"Stage {i+1}")
+            exit_triggers = stage.get("exit_triggers", [])
+            
+            for trigger_idx, trigger in enumerate(exit_triggers):
+                if not isinstance(trigger, dict):
+                    continue
+                
+                trigger_type = trigger.get("type")
+                if trigger_type is not None and trigger_type not in valid_trigger_types:
+                    errors.append(
+                        f"Stage '{stage_name}' exit trigger {trigger_idx+1} has invalid type '{trigger_type}'. "
+                        f"Must be one of: {', '.join(sorted(valid_trigger_types))}."
+                    )
+                
+                comparison = trigger.get("comparison")
+                if comparison is not None and comparison not in valid_comparisons:
+                    errors.append(
+                        f"Stage '{stage_name}' exit trigger {trigger_idx+1} has invalid comparison '{comparison}'. "
+                        f"Must be one of: '>=', '<='."
+                    )
+        
+        return errors
+
+    def _validate_limit_types(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate limit type values in profile (MACHINE level check).
+
+        Limit type must be one of: 'pressure', 'flow'.
+
+        Args:
+            profile: Profile dictionary to validate
+
+        Returns:
+            List of limit type validation errors
+        """
+        errors = []
+        valid_limit_types = {"pressure", "flow"}
+
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+
+        for i, stage in enumerate(profile["stages"]):
+            if not isinstance(stage, dict):
+                continue
+
+            stage_name = stage.get("name", f"Stage {i+1}")
+            limits = stage.get("limits", [])
+
+            if not isinstance(limits, list):
+                continue
+
+            for limit_idx, limit in enumerate(limits):
+                if not isinstance(limit, dict):
+                    continue
+
+                limit_type = limit.get("type")
+                if limit_type is not None and limit_type not in valid_limit_types:
+                    errors.append(
+                        f"Stage '{stage_name}' limit {limit_idx+1} has invalid type '{limit_type}'. "
+                        f"Must be one of: 'pressure', 'flow'."
+                    )
+
+        return errors
+
+    def _validate_redundant_limits(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate that limits are not redundant with stage control type (SAFETY level check).
+
+        A limit cannot have the same type as the stage control type, as this is
+        redundant and the Meticulous app will reject it.
+
+        Args:
+            profile: Profile dictionary to validate
+
+        Returns:
+            List of redundant limit validation errors
+        """
+        errors = []
+
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+
+        for i, stage in enumerate(profile["stages"]):
+            if not isinstance(stage, dict):
+                continue
+
+            stage_name = stage.get("name", f"Stage {i+1}")
+            stage_type = stage.get("type")
+            limits = stage.get("limits", [])
+
+            if not isinstance(limits, list):
+                continue
+
+            for limit in limits:
+                if not isinstance(limit, dict):
+                    continue
+
+                limit_type = limit.get("type")
+                if limit_type is not None and stage_type is not None and limit_type == stage_type:
+                    errors.append(
+                        f"Stage '{stage_name}' has a '{limit_type}' limit but is a '{stage_type}' control stage. "
+                        f"This is redundant - you cannot limit {limit_type} when you're already controlling {stage_type}. "
+                        f"Use a '{('pressure' if limit_type == 'flow' else 'flow')}' limit instead, or remove the limit."
+                    )
+
+        return errors
+
+    def _validate_exit_trigger_matches_stage_type(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate that exit trigger types don't match the stage control type.
+        
+        If a stage controls flow, it should not have a flow exit trigger as the primary trigger.
+        If a stage controls pressure, it should not have a pressure exit trigger.
+        This creates a paradox where grind variations mean the trigger may never fire.
+        
+        Args:
+            profile: Profile dictionary to validate
+            
+        Returns:
+            List of validation errors
+        """
+        errors = []
+        
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+        
+        for i, stage in enumerate(profile["stages"]):
+            if not isinstance(stage, dict):
+                continue
+            
+            stage_name = stage.get("name", f"Stage {i+1}")
+            stage_type = stage.get("type")
+            exit_triggers = stage.get("exit_triggers", [])
+            
+            if not stage_type or not exit_triggers:
+                continue
+            
+            # Check if any exit trigger has the same type as the stage control
+            for trigger_idx, trigger in enumerate(exit_triggers):
+                if not isinstance(trigger, dict):
+                    continue
+                
+                trigger_type = trigger.get("type")
+                
+                # Check for matching types (flow stage with flow trigger, pressure stage with pressure trigger)
+                if trigger_type == stage_type and stage_type in ("flow", "pressure"):
+                    errors.append(
+                        f"Stage '{stage_name}' is a '{stage_type}' control stage but has a '{trigger_type}' exit trigger. "
+                        f"This is problematic - if you're controlling {stage_type}, you can't reliably exit based on {trigger_type} "
+                        f"since it's what you're already controlling. Use a different trigger type like 'time', 'weight', or "
+                        f"'{('pressure' if stage_type == 'flow' else 'flow')}'."
+                    )
+        
+        return errors
+
+    def _validate_backup_exit_triggers(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate that every stage has a backup/failsafe exit trigger.
+        
+        Every stage should have either:
+        - Multiple exit triggers (OR logic provides failsafe)
+        - At least one time-based trigger (universal failsafe)
+        
+        This prevents shots from stalling indefinitely if grind is wrong.
+        
+        Args:
+            profile: Profile dictionary to validate
+            
+        Returns:
+            List of validation errors
+        """
+        errors = []
+        
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+        
+        for i, stage in enumerate(profile["stages"]):
+            if not isinstance(stage, dict):
+                continue
+            
+            stage_name = stage.get("name", f"Stage {i+1}")
+            exit_triggers = stage.get("exit_triggers", [])
+            
+            if not exit_triggers:
+                # Already caught by other validation
+                continue
+            
+            # Count valid triggers and check for time trigger
+            valid_triggers = [t for t in exit_triggers if isinstance(t, dict) and t.get("type")]
+            has_time_trigger = any(t.get("type") == "time" for t in valid_triggers)
+            
+            # Must have either multiple triggers OR a time trigger
+            if len(valid_triggers) == 1 and not has_time_trigger:
+                trigger_type = valid_triggers[0].get("type", "unknown")
+                errors.append(
+                    f"Stage '{stage_name}' has only one exit trigger ('{trigger_type}') with no time-based failsafe. "
+                    f"Every stage must have a backup exit condition to prevent indefinite stalls. "
+                    f"Add a time-based trigger (e.g., 'time >= 45s') as a failsafe, or add a second trigger like 'weight'."
+                )
+        
+        return errors
+
+    def _validate_required_limits(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate that every stage has required safety limits.
+        
+        Flow stages must have a pressure limit to prevent machine stall at high pressure.
+        Pressure stages must have a flow limit to prevent gusher shots.
+        
+        Args:
+            profile: Profile dictionary to validate
+            
+        Returns:
+            List of validation errors
+        """
+        errors = []
+        
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+        
+        for i, stage in enumerate(profile["stages"]):
+            if not isinstance(stage, dict):
+                continue
+            
+            stage_name = stage.get("name", f"Stage {i+1}")
+            stage_type = stage.get("type")
+            limits = stage.get("limits", [])
+            
+            if not stage_type:
+                continue
+            
+            # Get limit types present
+            limit_types = set()
+            if isinstance(limits, list):
+                for limit in limits:
+                    if isinstance(limit, dict) and limit.get("type"):
+                        limit_types.add(limit.get("type"))
+            
+            # Determine if this is a pre-infusion stage (for different pressure limit recommendations)
+            stage_name_lower = stage_name.lower()
+            is_preinfusion = any(term in stage_name_lower for term in 
+                                 ["pre-infusion", "preinfusion", "fill", "bloom", "soak", "pre infusion"])
+            
+            # Flow stages need pressure limits
+            if stage_type == "flow" and "pressure" not in limit_types:
+                recommended_limit = "3 bar" if is_preinfusion else "10 bar"
+                errors.append(
+                    f"Stage '{stage_name}' is a 'flow' control stage but has no pressure limit. "
+                    f"This is dangerous - if the grind is too fine, pressure could spike to 12+ bar and stall. "
+                    f"Add a pressure limit (recommended: {recommended_limit} for {'pre-infusion' if is_preinfusion else 'extraction'} stages)."
+                )
+            
+            # Pressure stages need flow limits
+            if stage_type == "pressure" and "flow" not in limit_types:
+                errors.append(
+                    f"Stage '{stage_name}' is a 'pressure' control stage but has no flow limit. "
+                    f"This can cause gusher shots if the grind is too coarse. "
+                    f"Add a flow limit (recommended: 5 ml/s)."
+                )
+        
+        return errors
+
+    def _validate_absolute_weight_triggers(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate that absolute weight triggers are strictly increasing across stages.
+        
+        If Stage N exits at absolute weight X, and Stage N+1 has absolute weight trigger Y,
+        then Y must be > X, otherwise the trigger will fire immediately.
+        
+        Args:
+            profile: Profile dictionary to validate
+            
+        Returns:
+            List of validation errors
+        """
+        errors = []
+        
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return errors
+        
+        stages = profile["stages"]
+        
+        # Track the maximum absolute weight trigger seen so far
+        max_absolute_weight = 0.0
+        max_weight_stage_name = None
+        
+        for i, stage in enumerate(stages):
+            if not isinstance(stage, dict):
+                continue
+            
+            stage_name = stage.get("name", f"Stage {i+1}")
+            exit_triggers = stage.get("exit_triggers", [])
+            
+            # Find absolute weight triggers in this stage
+            for trigger in exit_triggers:
+                if not isinstance(trigger, dict):
+                    continue
+                
+                trigger_type = trigger.get("type")
+                trigger_value = trigger.get("value")
+                is_relative = trigger.get("relative", False)
+                
+                if trigger_type == "weight" and not is_relative and isinstance(trigger_value, (int, float)):
+                    # This is an absolute weight trigger
+                    if trigger_value <= max_absolute_weight and max_weight_stage_name is not None:
+                        errors.append(
+                            f"Stage '{stage_name}' has absolute weight trigger ({trigger_value}g) that is <= "
+                            f"the previous stage '{max_weight_stage_name}' weight trigger ({max_absolute_weight}g). "
+                            f"This trigger will fire immediately since the scale already shows >= {max_absolute_weight}g. "
+                            f"Use 'relative: true' for stage-specific weight tracking, or increase the weight threshold."
+                        )
+                    
+                    # Update max for next stages
+                    if trigger_value > max_absolute_weight:
+                        max_absolute_weight = trigger_value
+                        max_weight_stage_name = stage_name
+        
+        return errors
+
+    def _build_emoji_pattern(self) -> "re.Pattern[str]":
+        """Build a compiled regex for detecting an emoji at the start of a string."""
+        return re.compile(
+            r'^['
+            r'\U0001F300-\U0001F9FF'  # Miscellaneous Symbols and Pictographs, Emoticons, etc.
+            r'\U00002600-\U000027BF'  # Misc symbols, Dingbats
+            r'\U00002100-\U0000214F'  # Letterlike Symbols (includes ℹ️ U+2139)
+            r'\U0001F000-\U0001F02F'  # Mahjong tiles
+            r'\U0001FA00-\U0001FAFF'  # Extended-A symbols
+            r'\uFE00-\uFE0F'          # Variation Selectors (emoji presentation)
+            r']'
+        )
+
+    def _variable_usage_map(self, profile: Dict[str, Any]) -> Dict[str, bool]:
+        """Return a dict mapping variable key → True if used in any stage dynamics."""
+        used: Dict[str, bool] = {}
+        if "stages" not in profile:
+            return used
+        for stage in profile["stages"]:
+            if not isinstance(stage, dict):
+                continue
+            dynamics = stage.get("dynamics", {})
+            points = dynamics.get("points", [])
+            for point in points:
+                if isinstance(point, list):
+                    for val in point:
+                        if isinstance(val, str) and val.startswith("$"):
+                            used[val[1:]] = True
+        return used
+
+    def _validate_variable_naming(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate variable naming conventions — emoji rules (STRICT level check).
+
+        Rules:
+        1. Info variables (adjustable=False) MUST have an emoji prefix in their name.
+        2. Adjustable variables (adjustable=True) must NOT have an emoji prefix.
+
+        Args:
+            profile: Profile dictionary to validate
+
+        Returns:
+            List of variable naming validation errors
+        """
+        errors = []
+        variables = profile.get("variables", [])
+        if not variables:
+            return errors
+
+        emoji_pattern = self._build_emoji_pattern()
+
+        for var in variables:
+            if not isinstance(var, dict):
+                continue
+            key = var.get("key")
+            name = var.get("name", "")
+            is_info = not var.get("adjustable", True)
+
+            if not key:
+                continue
+
+            has_emoji = bool(emoji_pattern.match(name))
+
+            if is_info and not has_emoji:
+                errors.append(
+                    f"Info variable '{key}' ({name}) must have an emoji prefix in its name. "
+                    f"Info variables are displayed to help the user understand the profile but "
+                    f"cannot be adjusted. Add an emoji like ℹ️, 📊, or 💡 at the start."
+                )
+
+            if not is_info and has_emoji:
+                errors.append(
+                    f"Adjustable variable '{key}' ({name}) should not have an emoji prefix. "
+                    f"Emoji prefixes are reserved for info (non-adjustable) variables to "
+                    f"visually distinguish them in the UI."
+                )
+
+        return errors
+
+    def _validate_unused_adjustable_variables(self, profile: Dict[str, Any]) -> List[str]:
+        """Validate that all adjustable variables are used in stage dynamics (SAFETY level check).
+
+        Adjustable variables are intended to be referenced as $key in dynamics points.
+        An adjustable variable that is never used is most likely a mistake.
+
+        Info variables (adjustable=False) are display-only and do not need to be used.
+
+        Args:
+            profile: Profile dictionary to validate
+
+        Returns:
+            List of unused-variable validation errors
+        """
+        errors = []
+        variables = profile.get("variables", [])
+        if not variables:
+            return errors
+
+        used_map = self._variable_usage_map(profile)
+
+        for var in variables:
+            if not isinstance(var, dict):
+                continue
+            key = var.get("key")
+            name = var.get("name", "")
+            is_info = not var.get("adjustable", True)
+
+            if key and not is_info and not used_map.get(key, False):
+                errors.append(
+                    f"Adjustable variable '{key}' ({name}) is defined but never used in any "
+                    f"stage dynamics. Either use it with ${key} in a dynamics point, mark it as "
+                    f"info-only (adjustable: false), or remove it."
+                )
+
         return errors
 
     def _format_error(self, error: ValidationError) -> str:
@@ -260,6 +897,11 @@ class ProfileValidator:
                         over = dynamics.get("over", "")
                         if over not in ["time", "weight", "piston_position"]:
                             warnings.append(f"Stage '{stage_name}' has invalid dynamics.over value '{over}' - should be 'time', 'weight', or 'piston_position'")
+                        
+                        # Check interpolation value
+                        interpolation = dynamics.get("interpolation", "")
+                        if interpolation not in ["linear", "curve"]:
+                            warnings.append(f"Stage '{stage_name}' has invalid interpolation '{interpolation}' - should be 'linear' or 'curve'. The value 'none' is not supported.")
                     
                     # Check stage type
                     stage_type = stage.get("type", "")
@@ -278,6 +920,76 @@ class ProfileValidator:
                         prev_keys = [s.get("key") for s in stages[:i] if isinstance(s, dict)]
                         if stage_key in prev_keys:
                             warnings.append(f"Stage '{stage_name}' has duplicate key '{stage_key}' - stage keys should be unique")
+                    
+                    # Check limit values for sensible bounds
+                    limits = stage.get("limits", [])
+                    if isinstance(limits, list):
+                        for limit in limits:
+                            if not isinstance(limit, dict):
+                                continue
+                            limit_type = limit.get("type")
+                            limit_value = limit.get("value")
+                            if isinstance(limit_value, (int, float)):
+                                if limit_type == "pressure":
+                                    if limit_value < 0:
+                                        warnings.append(f"Stage '{stage_name}' has negative pressure limit ({limit_value} bar) - should be >= 0")
+                                    elif limit_value > 12:
+                                        warnings.append(f"Stage '{stage_name}' has very high pressure limit ({limit_value} bar) - consider lowering to 10-12 bar for safety")
+                                elif limit_type == "flow":
+                                    if limit_value < 0:
+                                        warnings.append(f"Stage '{stage_name}' has negative flow limit ({limit_value} ml/s) - should be >= 0")
+                                    elif limit_value > 8:
+                                        warnings.append(f"Stage '{stage_name}' has very high flow limit ({limit_value} ml/s) - consider lowering to 5-6 ml/s for better control")
+                    
+                    # Pre-infusion specific recommendations
+                    stage_name_lower = stage_name.lower()
+                    is_preinfusion = any(term in stage_name_lower for term in 
+                                         ["pre-infusion", "preinfusion", "fill", "bloom", "soak", "pre infusion"])
+                    if is_preinfusion:
+                        # Check for high pressure limits on pre-infusion stages
+                        if isinstance(limits, list):
+                            for limit in limits:
+                                if isinstance(limit, dict) and limit.get("type") == "pressure":
+                                    limit_value = limit.get("value")
+                                    if isinstance(limit_value, (int, float)) and limit_value > 4:
+                                        warnings.append(f"Stage '{stage_name}' is a pre-infusion stage with pressure limit of {limit_value} bar - consider lowering to 3-4 bar for gentler saturation")
+                        
+                        # Check for weight-based early exit (adaptive pre-infusion)
+                        has_weight_trigger = any(et.get("type") == "weight" for et in exit_triggers if isinstance(et, dict))
+                        if not has_weight_trigger:
+                            warnings.append(f"Stage '{stage_name}' is a pre-infusion stage without a weight-based exit trigger. Consider adding 'weight >= 3-5g' to detect early dripping and adapt to grind variations.")
+                    
+                    # Check for bloom/soak/hold stages that should use relative triggers
+                    is_bloom_stage = any(term in stage_name_lower for term in 
+                                         ["bloom", "soak", "hold", "rest", "pause", "wait"])
+                    if is_bloom_stage and i > 0:  # Only warn for non-first stages
+                        # Check if any exit triggers are absolute (relative=false)
+                        has_absolute_trigger = False
+                        for trigger in exit_triggers:
+                            if isinstance(trigger, dict):
+                                if not trigger.get("relative", False):
+                                    has_absolute_trigger = True
+                                    break
+                        if has_absolute_trigger:
+                            warnings.append(
+                                f"Stage '{stage_name}' appears to be a bloom/rest stage but uses absolute exit triggers. "
+                                f"Consider using 'relative: true' for exit triggers so the stage duration is independent of previous stages."
+                            )
+                    
+                    # Check for low absolute weight triggers in non-first stages
+                    if i > 0:  # Not the first stage
+                        for trigger in exit_triggers:
+                            if isinstance(trigger, dict):
+                                trigger_type = trigger.get("type")
+                                trigger_value = trigger.get("value")
+                                is_relative = trigger.get("relative", False)
+                                if trigger_type == "weight" and not is_relative and isinstance(trigger_value, (int, float)):
+                                    if trigger_value < 10:
+                                        warnings.append(
+                                            f"Stage '{stage_name}' (stage {i+1}) has a low absolute weight trigger ({trigger_value}g). "
+                                            f"If preceding stages have weight-based exits, this may fire immediately. "
+                                            f"Consider using 'relative: true' for stage-specific weight tracking."
+                                        )
         
         # Check temperature range
         if "temperature" in profile:
@@ -301,14 +1013,31 @@ class ProfileValidator:
                 elif weight > 60:
                     warnings.append(f"Final weight {weight}g is quite high - this approaches lungo/ristretto territory")
         
-        # Check variables
-        if "variables" in profile:
-            variables = profile["variables"]
-            if variables:
+        # Check variables - the variables array should always exist for app compatibility
+        # Handle three cases: missing key, empty array, or populated array
+        if "variables" not in profile:
+            # Case 1: Key missing entirely - most critical, affects app compatibility
+            warnings.append(
+                "Profile is missing 'variables' array - this field must be present (even if empty) "
+                "for Meticulous app compatibility. The app may crash when trying to add variables."
+            )
+        else:
+            variables = profile.get("variables", [])
+            if not variables:
+                # Case 2: Empty array - valid but could be more useful
+                warnings.append(
+                    "Profile has no variables defined - consider adding variables (e.g., target pressure, "
+                    "bloom flow rate) for easier adjustments during brewing. Variables allow you to tweak "
+                    "profile parameters without editing individual stage dynamics."
+                )
+            else:
+                # Case 3: Has variables - check for undefined references and unused variables
                 var_keys = [v.get("key") for v in variables if isinstance(v, dict)]
-                # Check for variables referenced in stages but not defined
+                
+                # Check for undefined variable references in stages
                 if "stages" in profile:
                     stages = profile["stages"]
+                    variables_used = set()
                     for stage in stages:
                         if not isinstance(stage, dict):
                             continue
@@ -320,8 +1049,14 @@ class ProfileValidator:
                                 for val in point:
                                     if isinstance(val, str) and val.startswith("$"):
                                         var_key = val[1:]  # Remove $
+                                        variables_used.add(var_key)
                                         if var_key not in var_keys:
                                             warnings.append(f"Stage '{stage.get('name', 'unknown')}' references variable '${var_key}' but it's not defined in variables")
+                    
+                    # Check for unused variables
+                    unused_vars = set(var_keys) - variables_used
+                    for unused in unused_vars:
+                        warnings.append(f"Variable '{unused}' is defined but never used in any stage dynamics")
 
         return warnings
 

--- a/meticulous-mcp/src/meticulous_mcp/profile_validator.py
+++ b/meticulous-mcp/src/meticulous_mcp/profile_validator.py
@@ -80,6 +80,15 @@ class ProfileValidator:
             level: Default validation level to use when none is passed to validate().
                    Defaults to ValidationLevel.SAFETY.
         """
+        # Validate and coerce the default validation level to a proper ValidationLevel
+        if not isinstance(level, ValidationLevel):
+            try:
+                level = ValidationLevel(level)
+            except (ValueError, TypeError) as exc:
+                raise TypeError(
+                    f"Invalid validation level {level!r}. Expected a ValidationLevel "
+                    f"or one of {[v.value for v in ValidationLevel]}."
+                ) from exc
         self._default_level = level
         possible_paths = []
         if schema_path is None:

--- a/meticulous-mcp/src/meticulous_mcp/profile_validator.py
+++ b/meticulous-mcp/src/meticulous_mcp/profile_validator.py
@@ -130,6 +130,16 @@ class ProfileValidator:
         if level is None:
             level = self._default_level
 
+        # Normalize level to a ValidationLevel instance to avoid incorrect comparisons
+        if isinstance(level, str):
+            try:
+                level = ValidationLevel(level)
+            except ValueError as exc:
+                raise ValueError(f"Unknown validation level: {level!r}") from exc
+        elif not isinstance(level, ValidationLevel):
+            raise TypeError(
+                f"level must be a ValidationLevel or str, got {type(level).__name__}"
+            )
         errors = []
         try:
             self._validator.validate(profile)

--- a/meticulous-mcp/src/meticulous_mcp/profile_validator.py
+++ b/meticulous-mcp/src/meticulous_mcp/profile_validator.py
@@ -295,11 +295,17 @@ class ProfileValidator:
             if isinstance(dynamics, dict):
                 interpolation = dynamics.get("interpolation")
                 if interpolation is not None and interpolation not in valid_interpolations:
-                    errors.append(
-                        f"Stage '{stage_name}' has invalid interpolation value '{interpolation}'. "
-                        f"Only 'linear' and 'curve' are supported. "
-                        f"The value 'none' is not supported by the Meticulous machine and will cause it to stall."
-                    )
+                    if interpolation == "none":
+                        errors.append(
+                            f"Stage '{stage_name}' has invalid interpolation value '{interpolation}'. "
+                            f"Only 'linear' and 'curve' are supported. "
+                            f"The value 'none' is not supported by the Meticulous machine and will cause it to stall."
+                        )
+                    else:
+                        errors.append(
+                            f"Stage '{stage_name}' has invalid interpolation value '{interpolation}'. "
+                            f"Only 'linear' and 'curve' are supported."
+                        )
                 
                 # Check that 'curve' interpolation has at least 2 points
                 points = dynamics.get("points", [])

--- a/meticulous-mcp/src/meticulous_mcp/profile_validator.py
+++ b/meticulous-mcp/src/meticulous_mcp/profile_validator.py
@@ -737,21 +737,32 @@ class ProfileValidator:
         )
 
     def _variable_usage_map(self, profile: Dict[str, Any]) -> Dict[str, bool]:
-        """Return a dict mapping variable key → True if used in any stage dynamics."""
+        """Return a dict mapping variable key → True if used anywhere in any stage.
+
+        Recursively scans every value in each stage object (dynamics points,
+        limits, exit_triggers, and any future nested fields) for $key variable
+        references.
+        """
         used: Dict[str, bool] = {}
         if "stages" not in profile:
             return used
         for stage in profile["stages"]:
             if not isinstance(stage, dict):
                 continue
-            dynamics = stage.get("dynamics", {})
-            points = dynamics.get("points", [])
-            for point in points:
-                if isinstance(point, list):
-                    for val in point:
-                        if isinstance(val, str) and val.startswith("$"):
-                            used[val[1:]] = True
+            self._collect_variable_refs(stage, used)
         return used
+
+    def _collect_variable_refs(self, obj: Any, used: Dict[str, bool]) -> None:
+        """Recursively find all $key variable references in a nested structure."""
+        if isinstance(obj, str):
+            if obj.startswith("$"):
+                used[obj[1:]] = True
+        elif isinstance(obj, list):
+            for item in obj:
+                self._collect_variable_refs(item, used)
+        elif isinstance(obj, dict):
+            for val in obj.values():
+                self._collect_variable_refs(val, used)
 
     def _get_max_dynamics_value(self, stage: Dict[str, Any]) -> Optional[float]:
         """Return the maximum numeric target value from a stage's dynamics points.

--- a/meticulous-mcp/src/meticulous_mcp/profile_validator.py
+++ b/meticulous-mcp/src/meticulous_mcp/profile_validator.py
@@ -582,61 +582,64 @@ class ProfileValidator:
 
     def _validate_required_limits(self, profile: Dict[str, Any]) -> List[str]:
         """Validate that every stage has required safety limits.
-        
+
         Flow stages must have a pressure limit to prevent machine stall at high pressure.
-        Pressure stages must have a flow limit to prevent gusher shots.
-        
+        Pressure stages at >= 6 bar must have a flow limit to prevent gusher shots.
+        Low-pressure stages (< 6 bar) are not a gusher risk and are skipped.
+
+        Recommended limit values are based on stage dynamics rather than stage names.
+
         Args:
             profile: Profile dictionary to validate
-            
+
         Returns:
             List of validation errors
         """
         errors = []
-        
+
         if "stages" not in profile or not isinstance(profile["stages"], list):
             return errors
-        
+
         for i, stage in enumerate(profile["stages"]):
             if not isinstance(stage, dict):
                 continue
-            
+
             stage_name = stage.get("name", f"Stage {i+1}")
             stage_type = stage.get("type")
             limits = stage.get("limits", [])
-            
+
             if not stage_type:
                 continue
-            
+
             # Get limit types present
             limit_types = set()
             if isinstance(limits, list):
                 for limit in limits:
                     if isinstance(limit, dict) and limit.get("type"):
                         limit_types.add(limit.get("type"))
-            
-            # Determine if this is a pre-infusion stage (for different pressure limit recommendations)
-            stage_name_lower = stage_name.lower()
-            is_preinfusion = any(term in stage_name_lower for term in 
-                                 ["pre-infusion", "preinfusion", "fill", "bloom", "soak", "pre infusion"])
-            
+
+            is_low_value = self._is_low_value_stage(stage)
+
             # Flow stages need pressure limits
             if stage_type == "flow" and "pressure" not in limit_types:
-                recommended_limit = "3 bar" if is_preinfusion else "10 bar"
+                recommended_limit = "3 bar" if is_low_value else "10 bar"
                 errors.append(
                     f"Stage '{stage_name}' is a 'flow' control stage but has no pressure limit. "
                     f"This is dangerous - if the grind is too fine, pressure could spike to 12+ bar and stall. "
-                    f"Add a pressure limit (recommended: {recommended_limit} for {'pre-infusion' if is_preinfusion else 'extraction'} stages)."
+                    f"Add a pressure limit (recommended: {recommended_limit} for {'low-flow' if is_low_value else 'extraction'} stages)."
                 )
-            
-            # Pressure stages need flow limits
+
+            # Pressure stages need flow limits — only when target pressure is >= 6 bar
+            # or when the target is unresolvable (variable references).
             if stage_type == "pressure" and "flow" not in limit_types:
-                errors.append(
-                    f"Stage '{stage_name}' is a 'pressure' control stage but has no flow limit. "
-                    f"This can cause gusher shots if the grind is too coarse. "
-                    f"Add a flow limit (recommended: 5 ml/s)."
-                )
-        
+                max_pressure = self._get_max_dynamics_value(stage)
+                if max_pressure is None or max_pressure >= 6.0:
+                    errors.append(
+                        f"Stage '{stage_name}' is a 'pressure' control stage but has no flow limit. "
+                        f"This can cause gusher shots if the grind is too coarse. "
+                        f"Add a flow limit (recommended: 5 ml/s)."
+                    )
+
         return errors
 
     def _validate_absolute_weight_triggers(self, profile: Dict[str, Any]) -> List[str]:
@@ -724,6 +727,61 @@ class ProfileValidator:
                         if isinstance(val, str) and val.startswith("$"):
                             used[val[1:]] = True
         return used
+
+    def _get_max_dynamics_value(self, stage: Dict[str, Any]) -> Optional[float]:
+        """Return the maximum numeric target value from a stage's dynamics points.
+
+        Variable references ($key) are skipped — we can only classify stages
+        with concrete numeric values.  Returns None when no numeric target
+        values are found.
+        """
+        dynamics = stage.get("dynamics", {})
+        points = dynamics.get("points", [])
+        max_val: Optional[float] = None
+        for point in points:
+            if isinstance(point, list):
+                for val in point[1:]:  # skip the x-axis value at index 0
+                    if isinstance(val, (int, float)):
+                        if max_val is None or val > max_val:
+                            max_val = val
+        return max_val
+
+    def _is_low_value_stage(self, stage: Dict[str, Any]) -> bool:
+        """Determine if a stage targets low values (pre-infusion-like behavior).
+
+        Classification thresholds:
+        - Flow stages: max target < 2 ml/s
+        - Pressure stages: max target < 4 bar
+
+        Returns False if dynamics contain only variable references (unresolvable).
+        """
+        stage_type = stage.get("type")
+        max_val = self._get_max_dynamics_value(stage)
+        if max_val is None:
+            return False
+        if stage_type == "flow":
+            return max_val < 2.0
+        if stage_type == "pressure":
+            return max_val < 4.0
+        return False
+
+    def _is_hold_stage(self, stage: Dict[str, Any]) -> bool:
+        """Determine if a stage holds constant (bloom/soak-like behavior).
+
+        A hold stage has either a single dynamics point or all numeric target
+        values are identical (flat curve).  Only evaluates numeric values.
+        """
+        dynamics = stage.get("dynamics", {})
+        points = dynamics.get("points", [])
+        numeric_values = []
+        for point in points:
+            if isinstance(point, list) and len(point) >= 2:
+                val = point[1]
+                if isinstance(val, (int, float)):
+                    numeric_values.append(val)
+        if len(numeric_values) <= 1:
+            return True
+        return all(v == numeric_values[0] for v in numeric_values)
 
     def _validate_variable_naming(self, profile: Dict[str, Any]) -> List[str]:
         """Validate variable naming conventions — emoji rules (STRICT level check).
@@ -940,42 +998,7 @@ class ProfileValidator:
                                         warnings.append(f"Stage '{stage_name}' has negative flow limit ({limit_value} ml/s) - should be >= 0")
                                     elif limit_value > 8:
                                         warnings.append(f"Stage '{stage_name}' has very high flow limit ({limit_value} ml/s) - consider lowering to 5-6 ml/s for better control")
-                    
-                    # Pre-infusion specific recommendations
-                    stage_name_lower = stage_name.lower()
-                    is_preinfusion = any(term in stage_name_lower for term in 
-                                         ["pre-infusion", "preinfusion", "fill", "bloom", "soak", "pre infusion"])
-                    if is_preinfusion:
-                        # Check for high pressure limits on pre-infusion stages
-                        if isinstance(limits, list):
-                            for limit in limits:
-                                if isinstance(limit, dict) and limit.get("type") == "pressure":
-                                    limit_value = limit.get("value")
-                                    if isinstance(limit_value, (int, float)) and limit_value > 4:
-                                        warnings.append(f"Stage '{stage_name}' is a pre-infusion stage with pressure limit of {limit_value} bar - consider lowering to 3-4 bar for gentler saturation")
-                        
-                        # Check for weight-based early exit (adaptive pre-infusion)
-                        has_weight_trigger = any(et.get("type") == "weight" for et in exit_triggers if isinstance(et, dict))
-                        if not has_weight_trigger:
-                            warnings.append(f"Stage '{stage_name}' is a pre-infusion stage without a weight-based exit trigger. Consider adding 'weight >= 3-5g' to detect early dripping and adapt to grind variations.")
-                    
-                    # Check for bloom/soak/hold stages that should use relative triggers
-                    is_bloom_stage = any(term in stage_name_lower for term in 
-                                         ["bloom", "soak", "hold", "rest", "pause", "wait"])
-                    if is_bloom_stage and i > 0:  # Only warn for non-first stages
-                        # Check if any exit triggers are absolute (relative=false)
-                        has_absolute_trigger = False
-                        for trigger in exit_triggers:
-                            if isinstance(trigger, dict):
-                                if not trigger.get("relative", False):
-                                    has_absolute_trigger = True
-                                    break
-                        if has_absolute_trigger:
-                            warnings.append(
-                                f"Stage '{stage_name}' appears to be a bloom/rest stage but uses absolute exit triggers. "
-                                f"Consider using 'relative: true' for exit triggers so the stage duration is independent of previous stages."
-                            )
-                    
+
                     # Check for low absolute weight triggers in non-first stages
                     if i > 0:  # Not the first stage
                         for trigger in exit_triggers:
@@ -1014,34 +1037,22 @@ class ProfileValidator:
                     warnings.append(f"Final weight {weight}g is quite high - this approaches lungo/ristretto territory")
         
         # Check variables - the variables array should always exist for app compatibility
-        # Handle three cases: missing key, empty array, or populated array
         if "variables" not in profile:
-            # Case 1: Key missing entirely - most critical, affects app compatibility
             warnings.append(
                 "Profile is missing 'variables' array - this field must be present (even if empty) "
                 "for Meticulous app compatibility. The app may crash when trying to add variables."
             )
         else:
             variables = profile.get("variables", [])
-            if not variables:
-                # Case 2: Empty array - valid but could be more useful
-                warnings.append(
-                    "Profile has no variables defined - consider adding variables (e.g., target pressure, "
-                    "bloom flow rate) for easier adjustments during brewing. Variables allow you to tweak "
-                    "profile parameters without editing individual stage dynamics."
-                )
-            else:
-                # Case 3: Has variables - check for undefined references and unused variables
-                var_keys = [v.get("key") for v in variables if isinstance(v, dict)]
-                
+            if variables:
                 # Check for undefined variable references in stages
+                var_keys = [v.get("key") for v in variables if isinstance(v, dict)]
+
                 if "stages" in profile:
                     stages = profile["stages"]
-                    variables_used = set()
                     for stage in stages:
                         if not isinstance(stage, dict):
                             continue
-                        # Check dynamics points for variable references
                         dynamics = stage.get("dynamics", {})
                         points = dynamics.get("points", [])
                         for point in points:
@@ -1049,14 +1060,74 @@ class ProfileValidator:
                                 for val in point:
                                     if isinstance(val, str) and val.startswith("$"):
                                         var_key = val[1:]  # Remove $
-                                        variables_used.add(var_key)
                                         if var_key not in var_keys:
                                             warnings.append(f"Stage '{stage.get('name', 'unknown')}' references variable '${var_key}' but it's not defined in variables")
-                    
-                    # Check for unused variables
-                    unused_vars = set(var_keys) - variables_used
-                    for unused in unused_vars:
-                        warnings.append(f"Variable '{unused}' is defined but never used in any stage dynamics")
 
         return warnings
+
+    def advise(self, profile: Dict[str, Any]) -> List[str]:
+        """Return opt-in design guidance for a profile.
+
+        Unlike lint() which flags structural anomalies, advise() suggests
+        design improvements based on espresso best practices.  These are
+        subjective recommendations, not errors.
+
+        Args:
+            profile: Profile dictionary to analyze
+
+        Returns:
+            List of design suggestions
+        """
+        suggestions: List[str] = []
+
+        if "stages" not in profile or not isinstance(profile["stages"], list):
+            return suggestions
+
+        stages = profile["stages"]
+        for i, stage in enumerate(stages):
+            if not isinstance(stage, dict):
+                continue
+
+            stage_name = stage.get("name", f"Stage {i+1}")
+            exit_triggers = stage.get("exit_triggers", [])
+            limits = stage.get("limits", [])
+            is_low_value = self._is_low_value_stage(stage)
+            is_hold = self._is_hold_stage(stage)
+
+            # Suggestion: Low-value stages with high pressure limits
+            if is_low_value and isinstance(limits, list):
+                for limit in limits:
+                    if isinstance(limit, dict) and limit.get("type") == "pressure":
+                        limit_value = limit.get("value")
+                        if isinstance(limit_value, (int, float)) and limit_value > 4:
+                            suggestions.append(
+                                f"Stage '{stage_name}' targets low values but has a pressure limit of "
+                                f"{limit_value} bar - consider lowering to 3-4 bar for gentler saturation."
+                            )
+
+            # Suggestion: Low-value stages without weight-based exit
+            if is_low_value:
+                has_weight_trigger = any(
+                    et.get("type") == "weight" for et in exit_triggers if isinstance(et, dict)
+                )
+                if not has_weight_trigger:
+                    suggestions.append(
+                        f"Stage '{stage_name}' targets low values without a weight-based exit trigger. "
+                        f"Consider adding 'weight >= 3-5g' to detect early dripping and adapt to grind variations."
+                    )
+
+            # Suggestion: Hold stages at low values with absolute triggers (bloom/soak pattern)
+            if is_hold and is_low_value and i > 0:
+                has_absolute_trigger = any(
+                    isinstance(t, dict) and not t.get("relative", False)
+                    for t in exit_triggers
+                )
+                if has_absolute_trigger:
+                    suggestions.append(
+                        f"Stage '{stage_name}' appears to be a hold/soak stage but uses absolute exit triggers. "
+                        f"Consider using 'relative: true' for exit triggers so the stage duration is "
+                        f"independent of previous stages."
+                    )
+
+        return suggestions
 

--- a/meticulous-mcp/tests/test_profile_validator.py
+++ b/meticulous-mcp/tests/test_profile_validator.py
@@ -1089,7 +1089,8 @@ def test_validate_valid_dynamics_over_passes(validator):
                 }
             ],
         }
-        is_valid, errors = validator.validate(profile)
+        is_valid, errors = validator.validate(profile, level=ValidationLevel.MACHINE)
+        assert is_valid
         over_errors = [e for e in errors if "dynamics.over" in e.lower()]
         assert len(over_errors) == 0
 

--- a/meticulous-mcp/tests/test_profile_validator.py
+++ b/meticulous-mcp/tests/test_profile_validator.py
@@ -2240,6 +2240,81 @@ def test_validate_variables_unused_info_passes(validator):
     assert not any("roast_level" in e.lower() and "never used" in e.lower() for e in errors)
 
 
+def test_validate_variable_used_in_limit_is_not_unused(validator):
+    """Test that a variable referenced in a limit value is counted as used."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Max Flow", "key": "max_flow", "adjustable": True, "value": 4.0}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, 8]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+                "limits": [{"type": "flow", "value": "$max_flow"}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not any("max_flow" in e.lower() and "never used" in e.lower() for e in errors)
+
+
+def test_validate_variable_used_in_exit_trigger_is_not_unused(validator):
+    """Test that a variable referenced in an exit trigger value is counted as used."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Target Weight", "key": "target_weight", "adjustable": True, "value": 40.0}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, 8]], "over": "time"},
+                "exit_triggers": [
+                    {"type": "weight", "value": "$target_weight"},
+                    {"type": "time", "value": 60},
+                ],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not any("target_weight" in e.lower() and "never used" in e.lower() for e in errors)
+
+
+def test_validate_variable_used_only_in_dynamics_is_not_unused(validator):
+    """Test that a variable referenced only in dynamics points is counted as used."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Target Pressure", "key": "target_pressure", "adjustable": True, "value": 8.0}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, "$target_pressure"]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not any("target_pressure" in e.lower() and "never used" in e.lower() for e in errors)
+
+
 # ==================== ValidationLevel System Tests ====================
 
 

--- a/meticulous-mcp/tests/test_profile_validator.py
+++ b/meticulous-mcp/tests/test_profile_validator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from meticulous_mcp.profile_validator import ProfileValidationError, ProfileValidator
+from meticulous_mcp.profile_validator import ProfileValidationError, ProfileValidator, ValidationLevel
 
 
 @pytest.fixture
@@ -859,3 +859,1434 @@ def test_validate_multiple_pressure_violations(validator):
     pressure_errors = [e for e in errors if ("15 bar limit" in e.lower() or "negative pressure" in e.lower())]
     assert len(pressure_errors) >= 3
 
+
+def test_validate_interpolation_none_fails(validator):
+    """Test validation fails when interpolation is 'none' (not supported by machine)."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Stage with none interpolation",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "none",  # This should fail
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("interpolation" in e.lower() and "none" in e.lower() and "not supported" in e.lower() for e in errors)
+
+
+def test_validate_interpolation_linear_passes(validator):
+    """Test validation passes when interpolation is 'linear'."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Stage with linear interpolation",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4], [10, 6]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "pressure", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    interpolation_errors = [e for e in errors if "interpolation" in e.lower()]
+    assert len(interpolation_errors) == 0
+
+
+def test_validate_interpolation_curve_passes(validator):
+    """Test validation passes when interpolation is 'curve'."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Stage with curve interpolation",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4], [10, 6]],
+                    "over": "time",
+                    "interpolation": "curve",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "pressure", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    interpolation_errors = [e for e in errors if "interpolation" in e.lower()]
+    assert len(interpolation_errors) == 0
+
+
+def test_validate_interpolation_invalid_value_fails(validator):
+    """Test validation fails for any invalid interpolation value."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Stage with invalid interpolation",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "invalid_value",  # This should fail
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("interpolation" in e.lower() for e in errors)
+
+
+def test_lint_interpolation_none_warns(validator):
+    """Test linting warns when interpolation is 'none'."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "none",
+                },
+                "exit_triggers": [{"type": "time", "value": 30}],
+            }
+        ],
+    }
+    warnings = validator.lint(profile)
+    assert any("interpolation" in w.lower() and "none" in w.lower() and "not supported" in w.lower() for w in warnings)
+
+
+# ==================== Additional Validation Tests ====================
+
+def test_validate_curve_interpolation_requires_two_points(validator):
+    """Test validation fails when curve interpolation has only 1 point."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Single Point Curve",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],  # Only 1 point with curve
+                    "over": "time",
+                    "interpolation": "curve",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("curve" in e.lower() and "2 points" in e.lower() for e in errors)
+
+
+def test_validate_curve_interpolation_with_two_points_passes(validator):
+    """Test validation passes when curve interpolation has 2+ points."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Multi Point Curve",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4], [10, 6]],  # 2 points - OK for curve
+                    "over": "time",
+                    "interpolation": "curve",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    curve_errors = [e for e in errors if "curve" in e.lower() and "2 points" in e.lower()]
+    assert len(curve_errors) == 0
+
+
+def test_validate_invalid_dynamics_over_fails(validator):
+    """Test validation fails for invalid dynamics.over values."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Invalid Over",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "invalid_value",  # Invalid
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("dynamics.over" in e.lower() and "invalid_value" in e for e in errors)
+
+
+def test_validate_valid_dynamics_over_passes(validator):
+    """Test validation passes for valid dynamics.over values."""
+    for over_value in ["time", "weight", "piston_position"]:
+        profile = {
+            "name": "Test Profile",
+            "id": "test-id",
+            "temperature": 90.0,
+            "stages": [
+                {
+                    "name": f"Stage with {over_value}",
+                    "key": "stage_1",
+                    "type": "flow",
+                    "dynamics": {
+                        "points": [[0, 4]],
+                        "over": over_value,
+                        "interpolation": "linear",
+                    },
+                    "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                    "limits": [],
+                }
+            ],
+        }
+        is_valid, errors = validator.validate(profile)
+        over_errors = [e for e in errors if "dynamics.over" in e.lower()]
+        assert len(over_errors) == 0
+
+
+def test_validate_invalid_stage_type_fails(validator):
+    """Test validation fails for invalid stage types."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Invalid Type",
+                "key": "stage_1",
+                "type": "invalid_type",  # Invalid
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("invalid type" in e.lower() and "invalid_type" in e for e in errors)
+
+
+def test_validate_valid_stage_types_pass(validator):
+    """Test validation passes for valid stage types."""
+    for stage_type in ["power", "flow", "pressure"]:
+        profile = {
+            "name": "Test Profile",
+            "id": "test-id",
+            "temperature": 90.0,
+            "stages": [
+                {
+                    "name": f"Stage with {stage_type}",
+                    "key": "stage_1",
+                    "type": stage_type,
+                    "dynamics": {
+                        "points": [[0, 4]],
+                        "over": "time",
+                        "interpolation": "linear",
+                    },
+                    "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                    "limits": [],
+                }
+            ],
+        }
+        is_valid, errors = validator.validate(profile)
+        type_errors = [e for e in errors if "invalid type" in e.lower()]
+        assert len(type_errors) == 0
+
+
+def test_validate_invalid_exit_trigger_type_fails(validator):
+    """Test validation fails for invalid exit trigger types."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Invalid Trigger",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "invalid_trigger", "value": 30}],
+                "limits": [],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("exit trigger" in e.lower() and "invalid_trigger" in e for e in errors)
+
+
+def test_validate_valid_exit_trigger_types_pass(validator):
+    """Test validation passes for valid exit trigger types."""
+    valid_types = ["weight", "pressure", "flow", "time", "piston_position", "power", "user_interaction"]
+    for trigger_type in valid_types:
+        profile = {
+            "name": "Test Profile",
+            "id": "test-id",
+            "temperature": 90.0,
+            "stages": [
+                {
+                    "name": f"Stage with {trigger_type}",
+                    "key": "stage_1",
+                    "type": "flow",
+                    "dynamics": {
+                        "points": [[0, 4]],
+                        "over": "time",
+                        "interpolation": "linear",
+                    },
+                    "exit_triggers": [{"type": trigger_type, "value": 30, "relative": True}],
+                    "limits": [],
+                }
+            ],
+        }
+        is_valid, errors = validator.validate(profile)
+        trigger_errors = [e for e in errors if "exit trigger" in e.lower() and "invalid" in e.lower()]
+        assert len(trigger_errors) == 0
+
+
+def test_validate_invalid_comparison_fails(validator):
+    """Test validation fails for invalid comparison operators."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Invalid Comparison",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "comparison": "=="}],  # Invalid
+                "limits": [],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("comparison" in e.lower() and "==" in e for e in errors)
+
+
+def test_validate_valid_comparisons_pass(validator):
+    """Test validation passes for valid comparison operators."""
+    for comparison in [">=", "<="]:
+        profile = {
+            "name": "Test Profile",
+            "id": "test-id",
+            "temperature": 90.0,
+            "stages": [
+                {
+                    "name": f"Stage with {comparison}",
+                    "key": "stage_1",
+                    "type": "flow",
+                    "dynamics": {
+                        "points": [[0, 4]],
+                        "over": "time",
+                        "interpolation": "linear",
+                    },
+                    "exit_triggers": [{"type": "time", "value": 30, "comparison": comparison, "relative": True}],
+                    "limits": [],
+                }
+            ],
+        }
+        is_valid, errors = validator.validate(profile)
+        comparison_errors = [e for e in errors if "comparison" in e.lower() and "invalid" in e.lower()]
+        assert len(comparison_errors) == 0
+
+
+def test_validate_invalid_limit_type_fails(validator):
+    """Test validation fails for invalid limit types."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Invalid Limit",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "invalid_limit", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("limit" in e.lower() and "invalid_limit" in e for e in errors)
+
+
+def test_validate_valid_limit_types_pass(validator):
+    """Test validation passes for valid limit types when not redundant with stage type."""
+    # Pressure limit on flow stage - valid
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Flow stage with pressure limit",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "pressure", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    limit_errors = [e for e in errors if "limit" in e.lower()]
+    assert len(limit_errors) == 0
+
+    # Flow limit on pressure stage - valid
+    profile2 = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Pressure stage with flow limit",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {
+                    "points": [[0, 9]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "flow", "value": 4}],
+            }
+        ],
+    }
+    is_valid2, errors2 = validator.validate(profile2)
+    limit_errors2 = [e for e in errors2 if "limit" in e.lower()]
+    assert len(limit_errors2) == 0
+
+
+def test_validate_redundant_flow_limit_on_flow_stage_fails(validator):
+    """Test validation fails when a flow stage has a flow limit (redundant)."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Pre-Wet & Bloom",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 3]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "flow", "value": 3}],  # Redundant!
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("redundant" in e.lower() and "flow" in e.lower() for e in errors)
+
+
+def test_validate_redundant_pressure_limit_on_pressure_stage_fails(validator):
+    """Test validation fails when a pressure stage has a pressure limit (redundant)."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Fruity Extraction",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {
+                    "points": [[0, 9]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "pressure", "value": 9}],  # Redundant!
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("redundant" in e.lower() and "pressure" in e.lower() for e in errors)
+
+
+# ==================== Exit Trigger Matches Stage Type Tests ====================
+
+def test_validate_flow_stage_with_flow_exit_trigger_fails(validator):
+    """Test validation fails when flow stage has flow exit trigger."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Flow Stage",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "flow", "value": 3, "relative": True}],
+                "limits": [{"type": "pressure", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("flow" in e.lower() and "control stage" in e.lower() and "exit trigger" in e.lower() for e in errors)
+
+
+def test_validate_pressure_stage_with_pressure_exit_trigger_fails(validator):
+    """Test validation fails when pressure stage has pressure exit trigger."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Pressure Stage",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {
+                    "points": [[0, 9]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "pressure", "value": 9, "relative": True}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("pressure" in e.lower() and "control stage" in e.lower() and "exit trigger" in e.lower() for e in errors)
+
+
+def test_validate_flow_stage_with_weight_exit_trigger_passes(validator):
+    """Test validation passes when flow stage has weight exit trigger."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Flow Stage",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [
+                    {"type": "weight", "value": 36, "relative": True},
+                    {"type": "time", "value": 45, "relative": True}
+                ],
+                "limits": [{"type": "pressure", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    stage_trigger_errors = [e for e in errors if "control stage" in e.lower() and "exit trigger" in e.lower()]
+    assert len(stage_trigger_errors) == 0
+
+
+# ==================== Backup Exit Trigger Tests ====================
+
+def test_validate_single_non_time_trigger_fails(validator):
+    """Test validation fails when stage has only one non-time exit trigger."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Flow Stage",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "weight", "value": 36, "relative": True}],  # Only weight, no time backup
+                "limits": [{"type": "pressure", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("backup" in e.lower() or "failsafe" in e.lower() for e in errors)
+
+
+def test_validate_single_time_trigger_passes(validator):
+    """Test validation passes when stage has only time trigger (it's a failsafe itself)."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Timed Stage",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "pressure", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    backup_errors = [e for e in errors if "backup" in e.lower() or "failsafe" in e.lower()]
+    assert len(backup_errors) == 0
+
+
+def test_validate_multiple_triggers_passes(validator):
+    """Test validation passes when stage has multiple exit triggers."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Multi-Trigger Stage",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [
+                    {"type": "weight", "value": 36, "relative": True},
+                    {"type": "time", "value": 45, "relative": True}
+                ],
+                "limits": [{"type": "pressure", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    backup_errors = [e for e in errors if "backup" in e.lower() or "failsafe" in e.lower()]
+    assert len(backup_errors) == 0
+
+
+# ==================== Required Limits Tests ====================
+
+def test_validate_flow_stage_without_pressure_limit_fails(validator):
+    """Test validation fails when flow stage has no pressure limit."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Flow Stage",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],  # No pressure limit!
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("flow" in e.lower() and "pressure limit" in e.lower() for e in errors)
+
+
+def test_validate_pressure_stage_without_flow_limit_fails(validator):
+    """Test validation fails when pressure stage has no flow limit."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Pressure Stage",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {
+                    "points": [[0, 9]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],  # No flow limit!
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("pressure" in e.lower() and "flow limit" in e.lower() for e in errors)
+
+
+def test_validate_flow_stage_with_pressure_limit_passes(validator):
+    """Test validation passes when flow stage has pressure limit."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Flow Stage",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 4]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "pressure", "value": 10}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    limit_errors = [e for e in errors if "pressure limit" in e.lower() or "flow limit" in e.lower()]
+    assert len(limit_errors) == 0
+
+
+def test_validate_pressure_stage_with_flow_limit_passes(validator):
+    """Test validation passes when pressure stage has flow limit."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Pressure Stage",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {
+                    "points": [[0, 9]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    limit_errors = [e for e in errors if "pressure limit" in e.lower() or "flow limit" in e.lower()]
+    assert len(limit_errors) == 0
+
+
+def test_validate_preinfusion_recommends_lower_pressure(validator):
+    """Test validation recommends 3 bar for pre-infusion stages."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Pre-infusion",  # Name indicates pre-infusion
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {
+                    "points": [[0, 3]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],  # Missing pressure limit
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    # Should recommend 3 bar for pre-infusion
+    assert any("3 bar" in e for e in errors)
+
+
+# ==================== Absolute Weight Trigger Tests ====================
+
+def test_validate_absolute_weight_decreasing_fails(validator):
+    """Test validation fails when absolute weight trigger decreases across stages."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Saturation",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 3]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [
+                    {"type": "weight", "value": 5, "relative": False, "comparison": ">="},
+                    {"type": "time", "value": 30, "relative": True}
+                ],
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+            {
+                "name": "Bloom",
+                "key": "stage_2",
+                "type": "flow",
+                "dynamics": {"points": [[0, 0]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [
+                    {"type": "weight", "value": 1, "relative": False, "comparison": ">="},  # Lower than previous!
+                    {"type": "time", "value": 10, "relative": True}
+                ],
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("absolute weight trigger" in e.lower() and "fire immediately" in e.lower() for e in errors)
+
+
+def test_validate_absolute_weight_increasing_passes(validator):
+    """Test validation passes when absolute weight triggers increase across stages."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Pre-infusion",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 3]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [
+                    {"type": "weight", "value": 5, "relative": False, "comparison": ">="},
+                    {"type": "time", "value": 30, "relative": True}
+                ],
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+            {
+                "name": "Extraction",
+                "key": "stage_2",
+                "type": "flow",
+                "dynamics": {"points": [[0, 4]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [
+                    {"type": "weight", "value": 36, "relative": False, "comparison": ">="},  # Higher - OK
+                    {"type": "time", "value": 45, "relative": True}
+                ],
+                "limits": [{"type": "pressure", "value": 10}],
+            },
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    weight_errors = [e for e in errors if "absolute weight trigger" in e.lower()]
+    assert len(weight_errors) == 0
+
+
+def test_validate_relative_weight_triggers_no_conflict(validator):
+    """Test validation passes when using relative weight triggers."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Pre-infusion",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 3]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [
+                    {"type": "weight", "value": 5, "relative": False, "comparison": ">="},
+                    {"type": "time", "value": 30, "relative": True}
+                ],
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+            {
+                "name": "Bloom",
+                "key": "stage_2",
+                "type": "flow",
+                "dynamics": {"points": [[0, 0]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [
+                    {"type": "weight", "value": 1, "relative": True, "comparison": ">="},  # Relative - OK
+                    {"type": "time", "value": 10, "relative": True}
+                ],
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    weight_errors = [e for e in errors if "absolute weight trigger" in e.lower()]
+    assert len(weight_errors) == 0
+
+
+def test_lint_bloom_stage_with_absolute_triggers_warns(validator):
+    """Test linting warns when bloom/rest stages use absolute triggers."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Fill",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 3]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [{"type": "time", "value": 10, "relative": True}],
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+            {
+                "name": "The Bloom Room",  # "bloom" in name
+                "key": "stage_2",
+                "type": "flow",
+                "dynamics": {"points": [[0, 0]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [{"type": "time", "value": 15, "relative": False}],  # Absolute
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+        ],
+    }
+    warnings = validator.lint(profile)
+    assert any("bloom" in w.lower() and "relative" in w.lower() for w in warnings)
+
+
+def test_lint_low_absolute_weight_in_later_stage_warns(validator):
+    """Test linting warns about low absolute weight triggers in non-first stages."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "First Stage",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 3]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [{"type": "time", "value": 10, "relative": True}],
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+            {
+                "name": "Second Stage",
+                "key": "stage_2",
+                "type": "flow",
+                "dynamics": {"points": [[0, 4]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [
+                    {"type": "weight", "value": 5, "relative": False},  # Low absolute in stage 2
+                    {"type": "time", "value": 30, "relative": True}
+                ],
+                "limits": [{"type": "pressure", "value": 10}],
+            },
+        ],
+    }
+    warnings = validator.lint(profile)
+    assert any("low absolute weight" in w.lower() and "5g" in w for w in warnings)
+
+
+# ==================== VARIABLES ARRAY REQUIREMENT TESTS ====================
+
+
+def test_lint_missing_variables_array_warns(validator):
+    """Test that missing variables array generates a warning (app compatibility)."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 3]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+            }
+        ],
+        # Note: no "variables" key at all
+    }
+    warnings = validator.lint(profile)
+    assert any("missing 'variables' array" in w.lower() for w in warnings)
+
+
+def test_lint_empty_variables_array_warns(validator):
+    """Test that empty variables array generates a suggestion warning."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [],  # Empty array is valid but not recommended
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 3]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+            }
+        ],
+    }
+    warnings = validator.lint(profile)
+    assert any("no variables defined" in w.lower() for w in warnings)
+
+
+def test_lint_profile_with_variables_no_warning(validator):
+    """Test that profile with proper variables doesn't warn about missing variables."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Target Pressure", "key": "target_pressure", "type": "pressure", "value": 8.0}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, "$target_pressure"]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+            }
+        ],
+    }
+    warnings = validator.lint(profile)
+    # Should not have any variable-related warnings
+    assert not any("no variables defined" in w.lower() for w in warnings)
+    assert not any("missing 'variables' array" in w.lower() for w in warnings)
+
+
+def test_lint_unused_variable_warns(validator):
+    """Test that unused variables generate a warning."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Used Var", "key": "active_pressure", "type": "pressure", "value": 8.0},
+            {"name": "Unused Var", "key": "dormant_flow", "type": "flow", "value": 3.0},
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, "$active_pressure"]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+            }
+        ],
+    }
+    warnings = validator.lint(profile)
+    # Check that dormant_flow (unused) generates a warning
+    assert any("dormant_flow" in w.lower() and "never used" in w.lower() for w in warnings)
+    # Check that active_pressure (used) does NOT generate a "never used" warning
+    assert not any("active_pressure" in w.lower() and "never used" in w.lower() for w in warnings)
+
+
+# Tests for _validate_variables (validation errors, not lint warnings)
+
+def test_validate_variables_info_without_emoji_fails(validator):
+    """Test that info variables without emoji prefix fail STRICT validation."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Target Weight", "key": "target_weight", "adjustable": False, "value": 36}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, 8]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.STRICT)
+    assert not is_valid
+    assert any("info variable" in e.lower() and "emoji prefix" in e.lower() for e in errors)
+
+
+def test_validate_variables_info_with_emoji_passes(validator):
+    """Test that info variables with emoji prefix pass STRICT validation."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "ℹ️ Target Weight", "key": "target_weight", "adjustable": False, "value": 36}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, 8]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.STRICT)
+    # Should not have emoji-related errors
+    assert not any("emoji" in e.lower() for e in errors)
+
+
+def test_validate_variables_adjustable_with_emoji_fails(validator):
+    """Test that adjustable variables with emoji prefix fail STRICT validation."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "🎯 Target Pressure", "key": "target_pressure", "adjustable": True, "value": 8.0}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, "$target_pressure"]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.STRICT)
+    assert not is_valid
+    assert any("adjustable variable" in e.lower() and "should not have an emoji" in e.lower() for e in errors)
+
+
+def test_validate_variables_adjustable_without_emoji_passes(validator):
+    """Test that adjustable variables without emoji prefix pass STRICT validation."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Target Pressure", "key": "target_pressure", "adjustable": True, "value": 8.0}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, "$target_pressure"]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.STRICT)
+    # Should not have emoji-related errors
+    assert not any("emoji" in e.lower() for e in errors)
+
+
+def test_validate_variables_unused_adjustable_fails(validator):
+    """Test that unused adjustable variables fail validation."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Unused Pressure", "key": "unused_pressure", "adjustable": True, "value": 8.0}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, 8]], "over": "time"},  # Not using $unused_pressure
+                "exit_triggers": [{"type": "time", "value": 30}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("unused_pressure" in e.lower() and "never used" in e.lower() for e in errors)
+
+
+def test_validate_variables_unused_info_passes(validator):
+    """Test that unused info variables pass validation (they're display-only)."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "ℹ️ Roast Level", "key": "roast_level", "adjustable": False, "value": "Medium"}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, 8]], "over": "time"},
+                "exit_triggers": [{"type": "time", "value": 30}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    # Unused info vars should not cause errors (they're for display)
+    assert not any("roast_level" in e.lower() and "never used" in e.lower() for e in errors)
+
+
+# ==================== ValidationLevel System Tests ====================
+
+
+# Shared helper profile that has ONLY a redundant limit (flow limit on flow stage)
+# and is otherwise valid at the MACHINE level (no pressure issues, good types, etc.).
+def _make_redundant_limit_profile():
+    return {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [],
+        "stages": [
+            {
+                "name": "Pre-Wet",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 3], [10, 3]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "flow", "value": 3}],  # Redundant: flow on flow stage
+            }
+        ],
+    }
+
+
+def _make_no_backup_trigger_profile():
+    """Profile with only a weight exit trigger — no time-based failsafe."""
+    return {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [],
+        "stages": [
+            {
+                "name": "Extraction",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 4], [10, 4]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [{"type": "weight", "value": 36, "relative": True}],
+                "limits": [{"type": "pressure", "value": 9}],
+            }
+        ],
+    }
+
+
+def _make_emoji_info_variable_profile():
+    """Profile with an info variable that is MISSING the required emoji prefix."""
+    return {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Roast Level", "key": "roast_level", "adjustable": False, "value": "Medium"}
+        ],
+        "stages": [
+            {
+                "name": "Stage 1",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, 9], [10, 9]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+
+
+def test_validate_default_is_safety_level(validator):
+    """Test that the default validation level is SAFETY."""
+    profile = _make_redundant_limit_profile()
+
+    # Default call — should behave the same as explicitly passing SAFETY
+    is_valid_default, errors_default = validator.validate(profile)
+    is_valid_safety, errors_safety = validator.validate(profile, level=ValidationLevel.SAFETY)
+
+    assert is_valid_default == is_valid_safety
+    assert errors_default == errors_safety
+
+
+def test_validate_machine_level_skips_redundant_limits(validator):
+    """Test that redundant limits are NOT caught at MACHINE level."""
+    profile = _make_redundant_limit_profile()
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.MACHINE)
+    redundant_errors = [e for e in errors if "redundant" in e.lower()]
+    assert len(redundant_errors) == 0
+
+
+def test_validate_safety_level_catches_redundant_limits(validator):
+    """Test that redundant limits ARE caught at SAFETY (default) level."""
+    profile = _make_redundant_limit_profile()
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.SAFETY)
+    assert not is_valid
+    assert any("redundant" in e.lower() and "flow" in e.lower() for e in errors)
+
+
+def test_validate_machine_level_skips_backup_trigger_check(validator):
+    """Test that the missing-backup-trigger check is skipped at MACHINE level."""
+    profile = _make_no_backup_trigger_profile()
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.MACHINE)
+    backup_errors = [e for e in errors if "backup" in e.lower() or "failsafe" in e.lower()]
+    assert len(backup_errors) == 0
+
+
+def test_validate_safety_level_catches_backup_trigger(validator):
+    """Test that a missing backup trigger is caught at SAFETY level."""
+    profile = _make_no_backup_trigger_profile()
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.SAFETY)
+    assert not is_valid
+    assert any("backup" in e.lower() or "failsafe" in e.lower() for e in errors)
+
+
+def test_validate_safety_level_skips_emoji_rules(validator):
+    """Test that emoji naming rules are NOT enforced at SAFETY (default) level."""
+    profile = _make_emoji_info_variable_profile()
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.SAFETY)
+    emoji_errors = [e for e in errors if "emoji" in e.lower()]
+    assert len(emoji_errors) == 0
+
+
+def test_validate_strict_level_catches_emoji_rules(validator):
+    """Test that emoji naming rules ARE enforced at STRICT level."""
+    profile = _make_emoji_info_variable_profile()
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.STRICT)
+    assert not is_valid
+    assert any("info variable" in e.lower() and "emoji prefix" in e.lower() for e in errors)
+
+
+def test_validate_strict_level_also_runs_safety_checks(validator):
+    """Test that STRICT level still runs all SAFETY-level checks."""
+    profile = _make_redundant_limit_profile()
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.STRICT)
+    # Redundant limit should still be caught even at STRICT level
+    assert not is_valid
+    assert any("redundant" in e.lower() for e in errors)
+
+
+def test_validate_machine_level_catches_invalid_pressure(validator):
+    """Test that over-pressure errors are always caught, even at MACHINE level."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "High Pressure Stage",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, 20]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.MACHINE)
+    assert not is_valid
+    assert any("15 bar limit" in e.lower() for e in errors)
+
+
+def test_validate_level_passed_to_validate_and_raise(validator):
+    """Test that validate_and_raise respects the level parameter."""
+    profile = _make_emoji_info_variable_profile()
+
+    # Should NOT raise at SAFETY level (emoji rules not checked)
+    validator.validate_and_raise(profile, level=ValidationLevel.SAFETY)
+
+    # Should raise at STRICT level (emoji rules enforced)
+    with pytest.raises(ProfileValidationError) as exc_info:
+        validator.validate_and_raise(profile, level=ValidationLevel.STRICT)
+    assert any("emoji" in e.lower() for e in exc_info.value.errors)
+
+
+def test_validator_constructor_default_level(sample_schema):
+    """Test that the constructor default level can be overridden."""
+    # Create a validator with MACHINE as default
+    machine_validator = ProfileValidator(schema_path=sample_schema, level=ValidationLevel.MACHINE)
+
+    profile = _make_redundant_limit_profile()
+    is_valid, errors = machine_validator.validate(profile)  # No level arg — uses constructor default
+    redundant_errors = [e for e in errors if "redundant" in e.lower()]
+    assert len(redundant_errors) == 0  # MACHINE default skips redundancy check
+
+
+def test_validator_constructor_strict_level(sample_schema):
+    """Test that a validator created with STRICT default enforces emoji rules without passing level."""
+    strict_validator = ProfileValidator(schema_path=sample_schema, level=ValidationLevel.STRICT)
+    profile = _make_emoji_info_variable_profile()
+    is_valid, errors = strict_validator.validate(profile)  # No level arg — uses STRICT default
+    assert not is_valid
+    assert any("emoji" in e.lower() for e in errors)

--- a/meticulous-mcp/tests/test_profile_validator.py
+++ b/meticulous-mcp/tests/test_profile_validator.py
@@ -1655,19 +1655,19 @@ def test_validate_pressure_stage_with_flow_limit_passes(validator):
     assert len(limit_errors) == 0
 
 
-def test_validate_preinfusion_recommends_lower_pressure(validator):
-    """Test validation recommends 3 bar for pre-infusion stages."""
+def test_validate_low_flow_stage_recommends_lower_pressure(validator):
+    """Test validation recommends 3 bar for low-flow stages (< 2 ml/s)."""
     profile = {
         "name": "Test Profile",
         "id": "test-id",
         "temperature": 90.0,
         "stages": [
             {
-                "name": "Pre-infusion",  # Name indicates pre-infusion
+                "name": "Pre-infusion",
                 "key": "stage_1",
                 "type": "flow",
                 "dynamics": {
-                    "points": [[0, 3]],
+                    "points": [[0, 1.5]],  # Low flow — below 2 ml/s threshold
                     "over": "time",
                     "interpolation": "linear",
                 },
@@ -1678,8 +1678,144 @@ def test_validate_preinfusion_recommends_lower_pressure(validator):
     }
     is_valid, errors = validator.validate(profile)
     assert not is_valid
-    # Should recommend 3 bar for pre-infusion
-    assert any("3 bar" in e for e in errors)
+    # Should recommend 3 bar for low-flow stages
+    assert any("3 bar" in e and "low-flow" in e for e in errors)
+
+
+def test_validate_low_pressure_stage_no_flow_limit_passes(validator):
+    """Test that low-pressure stages (< 6 bar) don't require a flow limit."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Gentle Pre-wet",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {
+                    "points": [[0, 2], [10, 3]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 15, "relative": True}],
+                "limits": [],  # No flow limit, but low pressure
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    flow_limit_errors = [e for e in errors if "flow limit" in e.lower()]
+    assert len(flow_limit_errors) == 0
+
+
+def test_validate_high_pressure_stage_no_flow_limit_fails(validator):
+    """Test that high-pressure stages (>= 6 bar) require a flow limit."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Extraction",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {
+                    "points": [[0, 9]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],  # No flow limit at 9 bar — dangerous
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert not is_valid
+    assert any("flow limit" in e.lower() for e in errors)
+
+
+def test_validate_pressure_variable_refs_no_flow_limit_fails(validator):
+    """Test that unresolvable variable refs still trigger flow limit warning."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "variables": [
+            {"name": "Pressure", "key": "p", "adjustable": True, "value": 9.0}
+        ],
+        "stages": [
+            {
+                "name": "Variable Stage",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {
+                    "points": [[0, "$p"]],
+                    "over": "time",
+                    "interpolation": "linear",
+                },
+                "exit_triggers": [{"type": "time", "value": 30, "relative": True}],
+                "limits": [],
+            }
+        ],
+    }
+    is_valid, errors = validator.validate(profile)
+    assert any("flow limit" in e.lower() for e in errors)
+
+
+def test_advise_returns_suggestions_for_low_value_hold(validator):
+    """Test advise() returns suggestions for a low-value hold stage with absolute triggers."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Fill",
+                "key": "stage_1",
+                "type": "flow",
+                "dynamics": {"points": [[0, 1.5]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [{"type": "time", "value": 10, "relative": True}],
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+            {
+                "name": "Bloom",
+                "key": "stage_2",
+                "type": "flow",
+                "dynamics": {"points": [[0, 0]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [{"type": "time", "value": 15, "relative": False}],
+                "limits": [{"type": "pressure", "value": 3}],
+            },
+        ],
+    }
+    suggestions = validator.advise(profile)
+    # Should suggest relative triggers for the hold/soak stage
+    assert any("hold/soak" in s.lower() for s in suggestions)
+    # Should suggest weight trigger for the low-value stage
+    assert any("weight" in s.lower() for s in suggestions)
+
+
+def test_advise_empty_for_well_formed_profile(validator):
+    """Test advise() returns empty list for a well-formed profile."""
+    profile = {
+        "name": "Test Profile",
+        "id": "test-id",
+        "temperature": 90.0,
+        "stages": [
+            {
+                "name": "Extraction",
+                "key": "stage_1",
+                "type": "pressure",
+                "dynamics": {"points": [[0, 6], [30, 9]], "over": "time", "interpolation": "linear"},
+                "exit_triggers": [
+                    {"type": "weight", "value": 36, "relative": True},
+                    {"type": "time", "value": 45, "relative": True},
+                ],
+                "limits": [{"type": "flow", "value": 5}],
+            }
+        ],
+    }
+    suggestions = validator.advise(profile)
+    assert len(suggestions) == 0
 
 
 # ==================== Absolute Weight Trigger Tests ====================
@@ -1792,8 +1928,8 @@ def test_validate_relative_weight_triggers_no_conflict(validator):
     assert len(weight_errors) == 0
 
 
-def test_lint_bloom_stage_with_absolute_triggers_warns(validator):
-    """Test linting warns when bloom/rest stages use absolute triggers."""
+def test_advise_hold_stage_with_absolute_triggers(validator):
+    """Test advise() suggests relative triggers for hold/soak stages."""
     profile = {
         "name": "Test Profile",
         "id": "test-id",
@@ -1808,7 +1944,7 @@ def test_lint_bloom_stage_with_absolute_triggers_warns(validator):
                 "limits": [{"type": "pressure", "value": 3}],
             },
             {
-                "name": "The Bloom Room",  # "bloom" in name
+                "name": "The Bloom Room",
                 "key": "stage_2",
                 "type": "flow",
                 "dynamics": {"points": [[0, 0]], "over": "time", "interpolation": "linear"},
@@ -1817,8 +1953,8 @@ def test_lint_bloom_stage_with_absolute_triggers_warns(validator):
             },
         ],
     }
-    warnings = validator.lint(profile)
-    assert any("bloom" in w.lower() and "relative" in w.lower() for w in warnings)
+    suggestions = validator.advise(profile)
+    assert any("hold/soak" in s.lower() and "relative" in s.lower() for s in suggestions)
 
 
 def test_lint_low_absolute_weight_in_later_stage_warns(validator):
@@ -1877,13 +2013,13 @@ def test_lint_missing_variables_array_warns(validator):
     assert any("missing 'variables' array" in w.lower() for w in warnings)
 
 
-def test_lint_empty_variables_array_warns(validator):
-    """Test that empty variables array generates a suggestion warning."""
+def test_lint_empty_variables_array_no_warning(validator):
+    """Test that empty variables array does NOT generate a warning (legitimate choice)."""
     profile = {
         "name": "Test Profile",
         "id": "test-id",
         "temperature": 90.0,
-        "variables": [],  # Empty array is valid but not recommended
+        "variables": [],  # Empty array is a valid design choice
         "stages": [
             {
                 "name": "Stage 1",
@@ -1895,7 +2031,8 @@ def test_lint_empty_variables_array_warns(validator):
         ],
     }
     warnings = validator.lint(profile)
-    assert any("no variables defined" in w.lower() for w in warnings)
+    assert not any("no variables defined" in w.lower() for w in warnings)
+    assert not any("missing 'variables' array" in w.lower() for w in warnings)
 
 
 def test_lint_profile_with_variables_no_warning(validator):
@@ -1923,8 +2060,8 @@ def test_lint_profile_with_variables_no_warning(validator):
     assert not any("missing 'variables' array" in w.lower() for w in warnings)
 
 
-def test_lint_unused_variable_warns(validator):
-    """Test that unused variables generate a warning."""
+def test_lint_does_not_warn_unused_variable(validator):
+    """Test that lint() does NOT warn about unused variables (handled by validate at SAFETY level)."""
     profile = {
         "name": "Test Profile",
         "id": "test-id",
@@ -1944,10 +2081,8 @@ def test_lint_unused_variable_warns(validator):
         ],
     }
     warnings = validator.lint(profile)
-    # Check that dormant_flow (unused) generates a warning
-    assert any("dormant_flow" in w.lower() and "never used" in w.lower() for w in warnings)
-    # Check that active_pressure (used) does NOT generate a "never used" warning
-    assert not any("active_pressure" in w.lower() and "never used" in w.lower() for w in warnings)
+    # lint() should NOT flag unused variables — that's validate()'s job
+    assert not any("dormant_flow" in w.lower() and "never used" in w.lower() for w in warnings)
 
 
 # Tests for _validate_variables (validation errors, not lint warnings)

--- a/meticulous-mcp/tests/test_profile_validator.py
+++ b/meticulous-mcp/tests/test_profile_validator.py
@@ -907,7 +907,8 @@ def test_validate_interpolation_linear_passes(validator):
             }
         ],
     }
-    is_valid, errors = validator.validate(profile)
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.MACHINE)
+    assert is_valid
     interpolation_errors = [e for e in errors if "interpolation" in e.lower()]
     assert len(interpolation_errors) == 0
 
@@ -933,7 +934,8 @@ def test_validate_interpolation_curve_passes(validator):
             }
         ],
     }
-    is_valid, errors = validator.validate(profile)
+    is_valid, errors = validator.validate(profile, level=ValidationLevel.MACHINE)
+    assert is_valid
     interpolation_errors = [e for e in errors if "interpolation" in e.lower()]
     assert len(interpolation_errors) == 0
 


### PR DESCRIPTION
## Summary

This PR contributes a substantial expansion of `ProfileValidator` built during development of [MeticAI](https://github.com/hessius/MeticAI), a companion app for the Meticulous espresso machine.

It adds **20 validation checks** across schema conformance, hardware safety, shot-safety best-practices, and UI convention categories — all organized under a new `ValidationLevel` enum so callers choose exactly how strict the validator should be.

---

## ValidationLevel System

A new `ValidationLevel(Enum)` with three tiers:

| Level | When to use |
|-------|-------------|
| `MACHINE` | Trust the author; catch only machine-breaking errors (bad types, pressure > 15 bar, invalid dynamics). |
| `SAFETY` _(default)_ | + Shot-safety best-practices: backup triggers, required limits, redundant limits, exit-trigger paradox. |
| `STRICT` | + Meticulous app UI conventions: emoji rules for info vs. adjustable variables. |

Usage:

```python
from meticulous_mcp.profile_validator import ProfileValidator, ValidationLevel

# Default (SAFETY):
validator = ProfileValidator()
is_valid, errors = validator.validate(profile)

# Per-call override:
is_valid, errors = validator.validate(profile, level=ValidationLevel.MACHINE)
is_valid, errors = validator.validate(profile, level=ValidationLevel.STRICT)

# Or set a different default at construction time:
strict_validator = ProfileValidator(level=ValidationLevel.STRICT)
```

---

## Full Validation Check Table

| # | Check | Category | MACHINE | SAFETY | STRICT |
|---|-------|----------|:-------:|:------:|:------:|
| 1 | Pressure > 15 bar in stage dynamics | Hardware limit | ✅ | ✅ | ✅ |
| 2 | Negative pressure in stage dynamics | Hardware limit | ✅ | ✅ | ✅ |
| 3 | Pressure > 15 bar in exit trigger | Hardware limit | ✅ | ✅ | ✅ |
| 4 | Negative pressure in exit trigger | Hardware limit | ✅ | ✅ | ✅ |
| 5 | Invalid `interpolation` value (not `linear`/`curve`) | Machine constraint | ✅ | ✅ | ✅ |
| 6 | `curve` interpolation requires ≥ 2 dynamics points | Machine constraint | ✅ | ✅ | ✅ |
| 7 | Invalid `dynamics.over` value | Machine constraint | ✅ | ✅ | ✅ |
| 8 | Invalid stage `type` | Machine constraint | ✅ | ✅ | ✅ |
| 9 | Invalid exit trigger `type` | Machine constraint | ✅ | ✅ | ✅ |
| 10 | Invalid `comparison` operator on exit trigger | Machine constraint | ✅ | ✅ | ✅ |
| 11 | Invalid limit `type` | Machine constraint | ✅ | ✅ | ✅ |
| 12 | Absolute weight triggers not monotonically increasing across stages | Machine constraint | ✅ | ✅ | ✅ |
| 13 | Redundant limit (same type as stage control, e.g. `flow` limit on `flow` stage) | Safety | ❌ | ✅ | ✅ |
| 14 | Exit trigger type matches stage control type (trigger-paradox) | Safety | ❌ | ✅ | ✅ |
| 15 | Stage has only one non-time exit trigger (no failsafe against stall) | Safety | ❌ | ✅ | ✅ |
| 16 | `flow` stage has no pressure limit (pressure spike risk) | Safety | ❌ | ✅ | ✅ |
| 17 | `pressure` stage has no flow limit (gusher risk) | Safety | ❌ | ✅ | ✅ |
| 18 | Adjustable variable defined but never referenced in stage dynamics | Safety | ❌ | ✅ | ✅ |
| 19 | Info variable (`adjustable: false`) missing emoji prefix in name | UI convention | ❌ | ❌ | ✅ |
| 20 | Adjustable variable has an emoji prefix (reserved for info variables) | UI convention | ❌ | ❌ | ✅ |

---

## Implementation Notes

- `_validate_limits` split into `_validate_limit_types` (MACHINE) + `_validate_redundant_limits` (SAFETY)
- `_validate_variables` split into `_validate_variable_naming` (STRICT) + `_validate_unused_adjustable_variables` (SAFETY)
- Helper methods `_build_emoji_pattern()` and `_variable_usage_map()` extracted for reuse
- `import re` moved to module level (was inside the function body)
- All type hints preserved; no new runtime dependencies

## Test Coverage

104 tests, all passing. New tests added:

- `test_validate_default_is_safety_level`
- `test_validate_machine_level_skips_redundant_limits`
- `test_validate_safety_level_catches_redundant_limits`
- `test_validate_machine_level_skips_backup_trigger_check`
- `test_validate_safety_level_catches_backup_trigger`
- `test_validate_safety_level_skips_emoji_rules`
- `test_validate_strict_level_catches_emoji_rules`
- `test_validate_strict_level_also_runs_safety_checks`
- `test_validate_machine_level_catches_invalid_pressure`
- `test_validate_level_passed_to_validate_and_raise`
- `test_validator_constructor_default_level`
- `test_validator_constructor_strict_level`

🤖 Generated with [Claude Code](https://claude.com/claude-code)